### PR TITLE
Fix: eliminate race conditions in RoundRobinJedisPool causing "use after closing" errors

### DIFF
--- a/src/main/java/io/codis/jodis/RoundRobinJedisPool.java
+++ b/src/main/java/io/codis/jodis/RoundRobinJedisPool.java
@@ -33,6 +33,8 @@ import static org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent.
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.curator.framework.CuratorFramework;
@@ -78,6 +80,8 @@ public class RoundRobinJedisPool implements JedisResourcePool {
 
     private static final int CURATOR_RETRY_MAX_SLEEP_MS = 30 * 1000;
 
+    private static final long DELAY_BEFORE_CLOSING_POOL = 10000; // milliseconds
+
     private static final ImmutableSet<PathChildrenCacheEvent.Type> RESET_TYPES = Sets
             .immutableEnumSet(CHILD_ADDED, CHILD_UPDATED, CHILD_REMOVED);
 
@@ -96,6 +100,15 @@ public class RoundRobinJedisPool implements JedisResourcePool {
             this.addr = addr;
             this.pool = pool;
         }
+
+        public Jedis getResource() {
+            return pool.getResource();
+        }
+
+        public void close() {
+            pool.close();
+            LOG.info("Connection pool to {} closed", addr);
+        }
     }
 
     private volatile ImmutableList<PooledObject> pools = ImmutableList.of();
@@ -113,6 +126,8 @@ public class RoundRobinJedisPool implements JedisResourcePool {
     private final int database;
 
     private final String clientName;
+
+    private final Timer jedisPoolClosingTimer = new Timer();
 
     private RoundRobinJedisPool(CuratorFramework curatorClient, boolean closeCurator,
             String zkProxyDir, JedisPoolConfig poolConfig, int connectionTimeoutMs, int soTimeoutMs,
@@ -199,9 +214,14 @@ public class RoundRobinJedisPool implements JedisResourcePool {
             }
         }
         this.pools = builder.build();
-        for (PooledObject pool: addr2Pool.values()) {
+        for (final PooledObject pool: addr2Pool.values()) {
             LOG.info("Remove proxy: " + pool.addr);
-            pool.pool.close();
+            jedisPoolClosingTimer.schedule(new TimerTask() {
+                @Override
+                public void run() {
+                    pool.close();
+                }
+            }, DELAY_BEFORE_CLOSING_POOL);
         }
     }
 
@@ -215,7 +235,7 @@ public class RoundRobinJedisPool implements JedisResourcePool {
             int current = nextIdx.get();
             int next = current >= pools.size() - 1 ? 0 : current + 1;
             if (nextIdx.compareAndSet(current, next)) {
-                return pools.get(next).pool.getResource();
+                return pools.get(next).getResource();
             }
         }
     }
@@ -233,8 +253,9 @@ public class RoundRobinJedisPool implements JedisResourcePool {
         List<PooledObject> pools = this.pools;
         this.pools = ImmutableList.of();
         for (PooledObject pool: pools) {
-            pool.pool.close();
+            pool.close();
         }
+        jedisPoolClosingTimer.cancel();
     }
 
     /**


### PR DESCRIPTION
This fix will enable scaling out of codis proxies w/o affecting codis clients

This fix will also enable rolling-restart of codis proxies w/o affecting codis clients. The rolling-restart process should be like:

```python
for proxy in proxies:
      mark_offline(proxy)  # set the status of 'proxy' to 'offline'
      sleep(10)  # wait 10 seconds for all ongoing requests to 'proxy' to be completed
      restart(proxy)  # kill 'proxy' and restart it
```

See 
     https://github.com/CodisLabs/jodis/pull/60 
for further details.